### PR TITLE
Fix unused preloaded font resource

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,14 @@ import Header from '@/components/header'
 import Footer from '@/components/footer'
 import Script from 'next/script'
 
-const inter = Inter({ subsets: ['latin'] })
+const inter = Inter({ 
+  subsets: ['latin'],
+  display: 'swap', // Use swap to show text immediately with fallback font
+  preload: false, // Disable automatic preloading to avoid unused preload warning
+  fallback: ['system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'arial'], // Comprehensive fallback fonts
+  adjustFontFallback: true, // Automatically adjust fallback fonts to reduce CLS
+  variable: '--font-inter', // Use CSS variable for better control
+})
 
 export const metadata: Metadata = {
   title: 'Hoobody - Your Premium Shopping Destination',
@@ -18,7 +25,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={inter.variable}>
       <body className={`${inter.className} min-h-screen flex flex-col`}>
         <Header />
         <main className="flex-1">


### PR DESCRIPTION
Disable automatic font preloading for Inter to resolve the 'unused preloaded resource' warning and improve font loading performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-62b6473c-9368-4d2e-8950-08174fcf6591">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62b6473c-9368-4d2e-8950-08174fcf6591">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

